### PR TITLE
Spelling fixes and fix for error when -o option not specified

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ where ``cwd`` is the current directory, ``listing`` is a list of ``FileEntry`` n
 
 * ``name``: File name, ``str``. Have a trailing / if it's a directory.
 * ``modified``: Last modification time, ``time.struct_time`` or ``None``. Timezone is not known.
-* ``size``: File size, ``int`` or ``None``. May be estimated from the prefiex, such as "K", "M".
+* ``size``: File size, ``int`` or ``None``. May be estimated from the prefix, such as "K", "M".
 * ``description``: File description, file type, or any other things found. ``str`` as HTML, or ``None``.
 
 Supports:
@@ -50,7 +50,7 @@ Reinvented HTTP Filesystem.
 
    optional arguments:
      -h, --help            show this help message and exit
-     -o OPTIONS            comma seperated FUSE options
+     -o OPTIONS            comma separated FUSE options
      -t TIMEOUT, --timeout TIMEOUT
                            HTTP request timeout
      -u USER_AGENT, --user-agent USER_AGENT

--- a/htmllistparse/rehttpfs.py
+++ b/htmllistparse/rehttpfs.py
@@ -376,7 +376,7 @@ class rehttpfs(fuse.LoggingMixIn, fuse.Operations):
 
 def main():
     parser = argparse.ArgumentParser(description="Mount HTML directory listings.")
-    parser.add_argument("-o", help="comma seperated FUSE options", metavar='OPTIONS')
+    parser.add_argument("-o", help="comma separated FUSE options", metavar='OPTIONS')
     parser.add_argument("-t", "--timeout", help="HTTP request timeout", type=int, default=30)
     parser.add_argument("-u", "--user-agent", help="HTTP User-Agent")
     parser.add_argument("-v", "--verbose", help="enable debug logging", action='store_true')

--- a/htmllistparse/rehttpfs.py
+++ b/htmllistparse/rehttpfs.py
@@ -46,12 +46,13 @@ def sizeof_fmt(num):
 
 def convert_fuse_options(options):
     kwargs = {}
-    for opt in options.split(','):
-        kv = opt.split('=', 1)
-        if len(kv) == 1:
-            kwargs[kv[0]] = True
-        else:
-            kwargs[kv[0]] = kv[1]
+    if options is not None:
+        for opt in options.split(','):
+            kv = opt.split('=', 1)
+            if len(kv) == 1:
+                kwargs[kv[0]] = True
+            else:
+                kwargs[kv[0]] = kv[1]
     return kwargs
 
 


### PR DESCRIPTION
This pull request fixes spelling errors and also fixes an error for when the optional "-o" option is not specified. Since -o is optional, not specifying should not result in an error (which it does now). This fixes #4 