### PR TITLE
Add **kwargs to fetch_listing function

### DIFF
--- a/htmllistparse/htmllistparse.py
+++ b/htmllistparse/htmllistparse.py
@@ -240,9 +240,9 @@ def parse(soup):
                 listing.append(FileEntry(file_name, None, None, None))
     return cwd, listing
 
-def fetch_listing(url, timeout=30):
+def fetch_listing(url, timeout=30, **requests_kwargs):
     import requests
-    req = requests.get(url, timeout=timeout)
+    req = requests.get(url, timeout=timeout, **requests_kwargs)
     req.raise_for_status()
     soup = bs4.BeautifulSoup(req.content, 'html5lib')
     return parse(soup)


### PR DESCRIPTION
Add kwargs to fetch_listing function in order to pass more variables to requests. 
The change allows defining variables like "verify=False" to skip certificate validation if required.