### PR TITLE
Fix time format with incomplete regex match.

### DIFF
--- a/htmllistparse/htmllistparse.py
+++ b/htmllistparse/htmllistparse.py
@@ -159,8 +159,9 @@ def parse(soup):
                         timestr = td.get_text().strip()
                         if timestr:
                             for regex, fmt in DATETIME_FMTs:
-                                if regex.match(timestr):
-                                    file_mod = time.strptime(timestr, fmt)
+                                match = regex.match(timestr)
+                                if match:
+                                    file_mod = time.strptime(match.group(0), fmt)
                                     break
                             else:
                                 if td.get('data-sort-value'):


### PR DESCRIPTION
`timestr` parsing relies on a series of time format regexes, `re.match`-ed against the timestr.
`re.match` returns a match for a prefix match, which is a desired behavior in this case.
Parse the match group, rather than the full `timestr` string.
This fixes cases where an time-zone suffix (+0000) is added to the reported time.