### PR TITLE
Take the first file entry if it is not a link to parent

### DIFF
--- a/htmllistparse/__init__.py
+++ b/htmllistparse/__init__.py
@@ -1,3 +1,3 @@
 from .htmllistparse import *
 
-__version__ = '0.5'
+__version__ = '0.6'

--- a/htmllistparse/htmllistparse.py
+++ b/htmllistparse/htmllistparse.py
@@ -96,8 +96,13 @@ def parse(soup):
                             file_name, file_mod, file_size, file_desc))
                     file_name = aherf2filename(element['href'])
                     file_mod = file_size = file_desc = None
-                elif (element.string in ('Parent Directory', '..', '../') or
-                      element['href'][0] not in '?/'):
+                elif element.string in ('Parent Directory', '..', '../'):
+                    # start with next a
+                    started = True
+                elif element['href'][0] not in '?/':
+                    # start right away
+                    file_name = aherf2filename(element['href'])
+                    file_mod = file_size = file_desc = None
                     started = True
             elif not element.name:
                 line = element.string.replace('\r', '').split('\n', 1)[0].lstrip()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if sys.version_info < (3, 3):
 
 setup(
     name='htmllistparse',
-    version='0.5.2',
+    version='0.6.0',
     description='Python parser for Apache/nginx-style HTML directory listing.',
     long_description=open('README.rst', 'r').read(),
     author='Dingyuan Wang',


### PR DESCRIPTION
Fixes #17 

`python htmllistparse/htmllistparse.py` still lists the full Debian listing, so that one is okay.

I did not test any other listings. And there is a lack of unit tests.